### PR TITLE
ILI and GFX font centering code

### DIFF
--- a/Examples/_Teensy3/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
+++ b/Examples/_Teensy3/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
@@ -1,0 +1,227 @@
+#include <Adafruit_GFX.h>
+
+#include <SPI.h>
+#include <RA8875.h>
+
+#include "font_Arial.h"
+#include "font_ArialBold.h"
+#include "font_ComicSansMS.h"
+#include "font_OpenSans.h"
+#include "font_DroidSans.h"
+#include "font_Michroma.h"
+#include "font_Crystal.h"
+#include "font_ChanceryItalic.h"
+
+// maybe a few GFX FOnts?
+#include <Fonts/FreeMonoBoldOblique12pt7b.h>
+#include <Fonts/FreeSerif12pt7b.h>
+
+typedef struct {
+  const ILI9341_t3_font_t *ili_font;
+  const GFXfont       *gfx_font;
+  const char          *font_name;
+  uint16_t            font_fg_color;
+  uint16_t            font_bg_color;
+} ili_fonts_test_t;
+
+
+const ili_fonts_test_t font_test_list[] = {
+  {&Arial_14, nullptr,  "Arial_14", RA8875_WHITE, RA8875_WHITE},
+  {&Arial_14_Bold, nullptr,  "ArialBold 14", RA8875_YELLOW, RA8875_YELLOW},
+  {&ComicSansMS_14, nullptr,  "ComicSansMS 14", RA8875_GREEN, RA8875_GREEN},
+  {&DroidSans_14, nullptr,  "DroidSans_14", RA8875_WHITE, RA8875_WHITE},
+  {&Michroma_14, nullptr,  "Michroma_14", RA8875_YELLOW, RA8875_YELLOW},
+  {&Crystal_24_Italic, nullptr,  "CRYSTAL_24", RA8875_BLACK, RA8875_YELLOW},
+  {&Chancery_24_Italic, nullptr,  "Chancery_24_Italic", RA8875_GREEN, RA8875_GREEN},
+  {&OpenSans24, nullptr,  "OpenSans 18", RA8875_RED, RA8875_YELLOW},
+  {nullptr, &FreeMonoBoldOblique12pt7b,  "GFX FreeMonoBoldOblique12pt7b", RA8875_WHITE, RA8875_WHITE},
+  {nullptr, &FreeMonoBoldOblique12pt7b,  "GFX FreeMonoBoldOblique12pt7b", RA8875_RED, RA8875_YELLOW},
+  {nullptr, &FreeSerif12pt7b,  "GFX FreeSerif12pt7b", RA8875_WHITE, RA8875_WHITE},
+  {nullptr, &FreeSerif12pt7b,  "GFX FreeSerif12pt7b", RA8875_RED, RA8875_YELLOW},
+
+} ;
+
+
+
+#define RA8875_CS 9
+#define RA8875_RST 8
+RA8875 tft = RA8875(RA8875_CS, RA8875_RST);
+uint8_t test_screen_rotation = 0;
+
+
+void setup() {
+  Serial.begin(38400);
+  long unsigned debug_start = millis ();
+  while (!Serial && ((millis () - debug_start) <= 5000)) ;
+  Serial.println("Setup");
+  //  begin display: Choose from: RA8875_480x272, RA8875_800x480, RA8875_800x480ALT, Adafruit_480x272, Adafruit_800x480
+  tft.begin(Adafruit_800x480);
+
+  tft.setRotation(4);
+  tft.fillWindow(RA8875_BLACK);
+
+  tft.setTextColor(RA8875_WHITE);
+  tft.setFont(Arial_14);
+  tft.println("Arial_14");
+  displayStuff();
+
+  tft.setTextColor(RA8875_YELLOW);
+  tft.setFont(Arial_14_Bold);
+  tft.println("ArialBold 14");
+  displayStuff();
+
+  tft.setTextColor(RA8875_GREEN);
+  tft.setFont(ComicSansMS_14);
+  tft.println("ComicSansMS 14");
+  displayStuff();
+
+  nextPage();
+
+  tft.setTextColor(RA8875_WHITE);
+  tft.setFont(DroidSans_14);
+  tft.println("DroidSans_14");
+  displayStuff();
+
+  tft.setTextColor(RA8875_YELLOW);
+  tft.setFont(Michroma_14);
+  tft.println("Michroma_14");
+  displayStuff();
+
+  tft.setTextColor(RA8875_BLACK, RA8875_YELLOW);
+  tft.setFont(Crystal_24_Italic);
+  tft.println("CRYSTAL_24");
+  displayStuff();
+
+  nextPage();
+
+  tft.setTextColor(RA8875_GREEN);
+  tft.setFont(Chancery_24_Italic);
+  tft.println("Chancery_24_Italic");
+  displayStuff();
+
+  //anti-alias font OpenSans
+  tft.setTextColor(RA8875_RED, RA8875_YELLOW);
+  tft.setFont(OpenSans24);
+  tft.println("OpenSans 18");
+  displayStuff();
+
+  Serial.println("Basic Font Display Complete");
+  Serial.println("Loop test for alt colors + font");
+}
+
+void loop()
+{
+  Serial.printf("\nRotation: %d\n", test_screen_rotation);
+  tft.setRotation(test_screen_rotation);
+  tft.fillWindow(RA8875_RED);
+  tft.setCursor(CENTER, CENTER);
+  tft.printf("Rotation: %d", test_screen_rotation);
+  test_screen_rotation = (test_screen_rotation + 1) & 0x3;
+  tft.setCursor(200, 300);
+  Serial.printf("  Set cursor(200, 300), retrieved(%d %d)",
+                tft.getCursorX(), tft.getCursorY());
+  tft.setCursor(50, 50);
+  tft.write('0');
+  tft.setCursor(tft.width() - 50, 50);
+  tft.write('1');
+  tft.setCursor(50, tft.height() - 50);
+  tft.write('2');
+  tft.setCursor(tft.width() - 50, tft.height() - 50);
+  tft.write('3');
+
+  for (uint8_t font_index = 0; font_index < (sizeof(font_test_list) / sizeof(font_test_list[0])); font_index++) {
+    nextPage();
+    if (font_test_list[font_index].font_fg_color != font_test_list[font_index].font_bg_color)
+      tft.setTextColor(font_test_list[font_index].font_fg_color, font_test_list[font_index].font_bg_color);
+    else
+      tft.setTextColor(font_test_list[font_index].font_fg_color);
+    if (font_test_list[font_index].ili_font) tft.setFont(*font_test_list[font_index].ili_font);
+    else tft.setFont(font_test_list[font_index].gfx_font);
+    tft.println(font_test_list[font_index].font_name);
+    displayStuff1();
+  }
+  nextPage();
+}
+
+uint32_t displayStuff()
+{
+  elapsedMillis elapsed_time = 0;
+  tft.println("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  tft.println("abcdefghijklmnopqrstuvwxyz");
+  tft.println("0123456789");
+  tft.println("!@#$%^ &*()-");
+  tft.println(); tft.println();
+  return (uint32_t) elapsed_time;
+}
+
+uint32_t displayStuff1()
+{
+  elapsedMillis elapsed_time = 0;
+  tft.println("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  tft.println("abcdefghijklmnopqrstuvwxyz");
+  tft.println("0123456789");
+  tft.println("!@#$%^ &*()-");
+
+  int16_t cursorX = tft.getCursorX();
+  int16_t cursorY = tft.getCursorY();
+
+  uint16_t width = tft.width();
+  uint16_t height = tft.height();
+  Serial.printf("DS1 (%d,%d) %d %d\n", cursorX, cursorY, width, height);
+  uint16_t rect_x = width / 2 - 50;
+  uint16_t rect_y = height - 75;
+  tft.drawRect(rect_x, rect_y, 100, 50, RA8875_WHITE);
+  for (uint16_t y = rect_y + 5; y < rect_y + 50; y += 5)
+    tft.drawFastHLine(rect_x + 1, y, 98, RA8875_PINK);
+  for (uint16_t x = rect_x + 5; x < rect_x + 100; x += 5)
+    tft.drawFastVLine(x, rect_y+1, 48, RA8875_PINK);
+  tft.setCursor(width / 2, height - 50, true);
+  tft.print("Center");
+
+  // Lets try again with CENTER X keyword.
+  rect_y -= 100;
+  tft.drawRect(rect_x, rect_y, 100, 50, RA8875_PINK);
+  for (uint16_t y = rect_y + 5; y < rect_y + 50; y += 5)
+    tft.drawFastHLine(rect_x + 1, y, 98, RA8875_CYAN);
+  for (uint16_t x = rect_x + 5; x < rect_x + 100; x += 5)
+    tft.drawFastVLine(x, rect_y+1, 48, RA8875_CYAN);
+  tft.setCursor(CENTER, rect_y);
+  tft.print("XCENTR");
+
+  // Lets try again with CENTER Y keyword.
+  rect_x = 50;
+  rect_y = tft.height()/2 -25;
+  tft.drawRect(rect_x, rect_y, 100, 50, RA8875_CYAN);
+  for (uint16_t y = rect_y + 5; y < rect_y + 50; y += 5)
+    tft.drawFastHLine(rect_x + 1, y, 98, RA8875_PINK);
+  for (uint16_t x = rect_x + 5; x < rect_x + 100; x += 5)
+  tft.setCursor(50, CENTER);
+  tft.print("YCENTR");
+  
+
+
+  tft.setCursor(cursorX, cursorY);
+  static const char alternating_text[] = "AbCdEfGhIjKlMnOpQrStUvWxYz\raBcDeFgHiJkLmNoPqRsTuVwXyZ";
+
+  for (uint8_t i = 0; i < sizeof(alternating_text); i++) {
+    if (i & 1) tft.setTextColor(RA8875_WHITE, RA8875_RED);
+    else tft.setTextColor(RA8875_YELLOW, RA8875_BLUE);
+    tft.write(alternating_text[i]);
+  }
+
+  tft.println(); tft.println();
+
+
+
+  return (uint32_t) elapsed_time;
+}
+
+void nextPage()
+{
+  Serial.println("Press anykey to continue");
+  while (Serial.read() == -1) ;
+  while (Serial.read() != -1) ;
+
+  tft.fillWindow(RA8875_BLACK);
+  tft.setCursor(0, 0);
+}

--- a/RA8875.cpp
+++ b/RA8875.cpp
@@ -1489,7 +1489,7 @@ void RA8875::setCursor(int16_t x, int16_t y,bool autocenter)
 	_absoluteCenter = autocenter;
 	
 	if (_portrait) {//rotation 1,3
-		swapvals(x,y);
+		if (_use_default) swapvals(x,y);
 		if (y == CENTER) {//swapped OK
 			y = _width/2;
 			if (!autocenter) {
@@ -5929,52 +5929,78 @@ void RA8875::writeCommand(const uint8_t d)
 	_endSend();
 }
 
-void RA8875::_fontWrite(uint8_t c)
+void RA8875::_fontWrite(const uint8_t* buffer, uint16_t len)
 {
 	if(_use_default) {
 		if (_FNTgrandient) _FNTgrandient = false;//cannot use this with write
-		_textWrite((const char *)&c, 1);
+		_textWrite((const char *)buffer, len);
 		//Serial.printf("Default: %c, %d, %d\n", c, _cursorX, _cursorY);
 		return;
 	}
-
-	if (font) {
-		//Serial.printf("ILI: %c, %d, %d\n", c, _cursorX, _cursorY);
-		if (c == '\n') {
-			//_cursorY += font->line_space;
-			//_cursorX  = 0;
-		} else {
-		  if (c == 13) {
-			_cursorY += font->line_space;
-			_cursorX  = 0;
-		  } else {
-			drawFontChar(c);
-		  }
-		}
-	} else if (gfxFont)  {
-		//Serial.printf("GFX: %c, %d, %d\n", c, _cursorX, _cursorY);
-		if (c == '\n') {
-            _cursorY += (int16_t)textsize_y * gfxFont->yAdvance;
-			_cursorX  = 0;
-		} else {
-			drawGFXFontChar(c);
-		}
-	} else {
-		if (c == '\n') {
-			_cursorY += textsize_y*8;
-			_cursorX  = 0;
-		} else if (c == '\r') {
-			// skip em
-		} else {
-			drawChar(_cursorX, _cursorY, c, textcolor, textbgcolor, textsize_x, textsize_y);
-			_cursorX += textsize_x*6;
-			if (wrap && (_cursorX > (_width - textsize_x*6))) {
-				_cursorY += textsize_y*6;
-				_cursorX = 0;
+	// Lets try to handle some of the special font centering code that was done for default fonts.
+	if (_absoluteCenter || _relativeCenter ) {
+		int16_t x, y;
+	  	uint16_t strngWidth, strngHeight;
+	  	getTextBounds(buffer, len, 0, 0, &x, &y, &strngWidth, &strngHeight);
+	  	//Serial.printf("_fontwrite bounds: %d %d %u %u\n", x, y, strngWidth, strngHeight);
+	  	// Note we may want to play with the x ane y returned if they offset some
+		if (_absoluteCenter && strngWidth > 0){//Avoid operations for strngWidth = 0
+			_absoluteCenter = false;
+			_cursorX = _cursorX - ((x + strngWidth) / 2);
+			_cursorY = _cursorY - ((y + strngHeight) / 2);
+		} else if (_relativeCenter && strngWidth > 0){//Avoid operations for strngWidth = 0
+			_relativeCenter = false;
+			if (bitRead(_TXTparameters,5)) {//X = center
+				_cursorX = (_width / 2) - ((x + strngWidth) / 2);
+				_TXTparameters &= ~(1 << 5);//reset
+			}
+			if (bitRead(_TXTparameters,6)) {//Y = center
+				_cursorY = (_height / 2) - ((y + strngHeight) / 2) ;
+				_TXTparameters &= ~(1 << 6);//reset
 			}
 		}
 	}
-	
+
+	while(len) {
+		uint8_t c = *buffer++;
+		if (font) {
+			//Serial.printf("ILI: %c, %d, %d\n", c, _cursorX, _cursorY);
+			if (c == '\n') {
+				//_cursorY += font->line_space;
+				//_cursorX  = 0;
+			} else {
+			  if (c == 13) {
+				_cursorY += font->line_space;
+				_cursorX  = 0;
+			  } else {
+				drawFontChar(c);
+			  }
+			}
+		} else if (gfxFont)  {
+			//Serial.printf("GFX: %c, %d, %d\n", c, _cursorX, _cursorY);
+			if (c == '\n') {
+	            _cursorY += (int16_t)textsize_y * gfxFont->yAdvance;
+				_cursorX  = 0;
+			} else {
+				drawGFXFontChar(c);
+			}
+		} else {
+			if (c == '\n') {
+				_cursorY += textsize_y*8;
+				_cursorX  = 0;
+			} else if (c == '\r') {
+				// skip em
+			} else {
+				drawChar(_cursorX, _cursorY, c, textcolor, textbgcolor, textsize_x, textsize_y);
+				_cursorX += textsize_x*6;
+				if (wrap && (_cursorX > (_width - textsize_x*6))) {
+					_cursorY += textsize_y*6;
+					_cursorX = 0;
+				}
+			}
+		}
+		len--;
+	}
 }
 
 
@@ -6711,6 +6737,28 @@ void RA8875::charBounds(char c, int16_t *x, int16_t *y,
 }
 
 // Add in Adafruit versions of text bounds calculations. 
+void RA8875::getTextBounds(const uint8_t *buffer, uint16_t len, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
+    *x1 = x;
+    *y1 = y;
+    *w  = *h = 0;
+
+    int16_t minx = _width, miny = _height, maxx = -1, maxy = -1;
+
+    while(len--)
+        charBounds(*buffer++, &x, &y, &minx, &miny, &maxx, &maxy);
+
+    if(maxx >= minx) {
+        *x1 = minx;
+        *w  = maxx - minx + 1;
+    }
+    if(maxy >= miny) {
+        *y1 = miny;
+        *h  = maxy - miny + 1;
+    }
+
+}
+
 void RA8875::getTextBounds(const char *str, int16_t x, int16_t y,
         int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h) {
     uint8_t c; // Current character

--- a/RA8875.h
+++ b/RA8875.h
@@ -371,6 +371,8 @@ class RA8875 : public Print
 	
 	void charBounds(char c, int16_t *x, int16_t *y,
 		int16_t *minx, int16_t *miny, int16_t *maxx, int16_t *maxy);
+    void getTextBounds(const uint8_t *buffer, uint16_t len, int16_t x, int16_t y,
+      int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
     void getTextBounds(const char *string, int16_t x, int16_t y,
       int16_t *x1, int16_t *y1, uint16_t *w, uint16_t *h);
     void getTextBounds(const String &str, int16_t x, int16_t y,
@@ -580,7 +582,7 @@ class RA8875 : public Print
 //}
 
 virtual size_t write(uint8_t c) {
-	_fontWrite(c);
+	_fontWrite(&c, 1);
 	return 1;
 }
 
@@ -588,8 +590,7 @@ virtual size_t write(const uint8_t *buffer, size_t size){
 	if(_use_default) {
 		_textWrite((const char *)buffer, size);
 	} else {
-		for(uint8_t j = 0; j < size; j++)
-		_fontWrite(buffer[j]);
+		_fontWrite(buffer, size);
 	}
 	return size;
 }
@@ -733,7 +734,7 @@ using Print::write;
 	uint32_t fetchbit(const uint8_t *p, uint32_t index);
 	uint32_t fetchbits_unsigned(const uint8_t *p, uint32_t index, uint32_t required);
 	uint32_t fetchbits_signed(const uint8_t *p, uint32_t index, uint32_t required);
-	void 	 _fontWrite(uint8_t c);
+	void 	 _fontWrite(const uint8_t* buffer, uint16_t len);
 	
 	/**
 	 * Found in a pull request for the Adafruit framebuffer library. Clever!


### PR DESCRIPTION
Add centering of text for GFX and ILI fonts...

This includes both the setCursor(x, y, true);
format which when you do a text output calculates the width and height
of your output and then centers the text at the x, y coordinate.

Also supports the X and/or Y coordinate of CENTER which like above
computes the width and height of the text output and then centers on one
or both axis.

Added new example text4 which tries out these capabilities.

While doing this I found there were several issues with the setCursor
and getCursor functions that were inconsistent with the usage of
swapping the X and Y coordinates when in portrait mode.

The test sketch outputs characters (0, 1, 2, 3) near the 4 corners when it changes rotation, so you can see if the set cursor is working properly.