### PR TITLE
GFX Font format change...

### DIFF
--- a/RA8875.h
+++ b/RA8875.h
@@ -215,6 +215,10 @@ typedef struct {
 
 
 // Lets see about supporting Adafruit fonts as well?
+#if __has_include(<gfxfont.h>)
+	#include <gfxfont.h>
+#endif
+
 #ifndef _GFXFONT_H_
 #define _GFXFONT_H_
 

--- a/examples/_Teensy3/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
+++ b/examples/_Teensy3/ILI_Ada_FontTest4/ILI_Ada_FontTest4.ino
@@ -56,7 +56,7 @@ void setup() {
   while (!Serial && ((millis () - debug_start) <= 5000)) ;
   Serial.println("Setup");
   //  begin display: Choose from: RA8875_480x272, RA8875_800x480, RA8875_800x480ALT, Adafruit_480x272, Adafruit_800x480
-  tft.begin(Adafruit_800x480);
+  tft.begin(Adafruit_800x480, 16, 15000000);
 
   tft.setRotation(4);
   tft.fillWindow(RA8875_BLACK);
@@ -140,6 +140,7 @@ void loop()
     else if (font_test_list[font_index].gfx_font)  tft.setFont(font_test_list[font_index].gfx_font);
     else tft.setFont(INTFONT);
     tft.println(font_test_list[font_index].font_name);
+    Serial.println(font_test_list[font_index].font_name);
     displayStuff1();
   }
   nextPage();
@@ -204,7 +205,8 @@ uint32_t displayStuff1()
   rect_x = 200;
   rect_y += 25; //center 
   static const char rectText[] = "RectText";
-  int16_t xT, yT, wT, hT;
+  int16_t xT, yT; 
+  uint16_t wT, hT;
   tft.getTextBounds(rectText, rect_x, rect_y, &xT, &yT, &wT, &hT);
   Serial.printf("getTextBounds: (%d, %d): %d %d %d %d\n", rect_x, rect_y, xT, yT, wT, hT);
   tft.setCursor(rect_x, rect_y);


### PR DESCRIPTION
@mjs513 @PaulStoffregen 
You might try this one out... 

Worked for me,  need to replicate into a few more libraries

Adafruit changed the format of the font file...

We have old format in our code...

Changed to if we have included GFX as part of our sketch than if yo uinclude RA8875.h file it uses the __has_include for the  gfxfont.h and includes it if your sketch has... So it then has the updated font format.